### PR TITLE
Fix Amplify config import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,10 @@
 // App.jsx / App.tsx
 import { NavLink, Routes, Route, Navigate } from 'react-router-dom';
-import { Amplify } from 'aws-amplify';
 import { signOut } from 'aws-amplify/auth';           // 👈 modular Auth
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
-import awsConfig from './awsConfig';                  // default export from CLI
 import Dashboard from './pages/Dashboard';
 import Customers from './pages/Customers';
-
-Amplify.configure(awsConfig);                         // still the same
 
 function App() {
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
 import { Amplify } from 'aws-amplify';
-import awsConfig   from './awsConfig.js';     // v6 config from the previous step
+import { awsConfig }   from './awsConfig.js';     // v6 config from the previous step
 import App         from './App.jsx';
 
 Amplify.configure(awsConfig);                // configure once, before render


### PR DESCRIPTION
## Summary
- configure Amplify once before render
- remove duplicate config call from `App.jsx`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684080415f1c8324972a3db0ae4a3f13