### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,8 +8,17 @@ import Customers from './pages/Customers';
 import CreatePass from './pages/CreatePass';
 import UpdatePass from './pages/UpdatePass';
 import Navbar from './components/Navbar';
+import { useEffect, useState } from 'react';
 
 function App() {
+    const [darkMode, setDarkMode] = useState(() => {
+        return localStorage.getItem('darkMode') === 'true';
+    });
+
+    useEffect(() => {
+        document.body.classList.toggle('dark', darkMode);
+        localStorage.setItem('darkMode', darkMode);
+    }, [darkMode]);
 
     async function handleSignOut() {
         // Either call the helper prop or the low-level API—your choice
@@ -19,7 +28,7 @@ function App() {
 
     return (
         <div className="container">
-            <Navbar onSignOut={handleSignOut} />
+            <Navbar onSignOut={handleSignOut} darkMode={darkMode} setDarkMode={setDarkMode} />
             <Routes>
                 <Route path="/" element={<Navigate to="/dashboard" replace />} />
                 <Route path="/dashboard" element={<Dashboard />} />

--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -5,6 +5,8 @@
   padding: 0.5rem 1rem;
   gap: 1rem;
   flex-wrap: wrap;
+  background-color: var(--navbar-bg);
+  color: var(--navbar-text);
 }
 
 .navbar-brand {
@@ -22,6 +24,13 @@
   display: flex;
   gap: 1rem;
   align-items: center;
+}
+
+.theme-toggle {
+  background: transparent;
+  border: 1px solid currentColor;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
 }
 
 .navbar nav a {

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,7 +1,9 @@
 import { NavLink } from 'react-router-dom';
 import './Navbar.css';
 
-export default function Navbar({ onSignOut }) {
+export default function Navbar({ onSignOut, darkMode, setDarkMode }) {
+    const toggleTheme = () => setDarkMode(!darkMode);
+
     return (
         <header className="navbar">
             <div className="navbar-brand">
@@ -14,6 +16,9 @@ export default function Navbar({ onSignOut }) {
                 <NavLink to="/customers">Customers</NavLink>
                 <NavLink to="/create-pass">Create Pass</NavLink>
                 <NavLink to="/update-pass">Update Pass</NavLink>
+                <button onClick={toggleTheme} className="theme-toggle">
+                    {darkMode ? 'Light Mode' : 'Dark Mode'}
+                </button>
                 <button onClick={onSignOut}>Sign&nbsp;out</button>
             </nav>
         </header>

--- a/src/index.css
+++ b/src/index.css
@@ -1,16 +1,26 @@
 :root {
+  --bg-color: #ffffff;
+  --text-color: #213547;
+  --navbar-bg: #1a1a1a;
+  --navbar-text: #ffffff;
+  --container-bg: #ffffff;
+
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+body.dark {
+  --bg-color: #242424;
+  --text-color: rgba(255, 255, 255, 0.87);
+  --navbar-bg: #ffffff;
+  --navbar-text: #242424;
+  --container-bg: #333333;
 }
 
 a {
@@ -29,6 +39,8 @@ body {
   min-width: 320px;
   min-height: 100vh;
   flex-direction: column;
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
 
 h1 {
@@ -74,6 +86,9 @@ nav a.active {
   padding: 2rem;
   max-width: 900px;
   width: 100%;
+  background-color: var(--container-bg);
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
 table {
@@ -91,15 +106,3 @@ tbody tr:nth-child(odd) {
 }
 
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}


### PR DESCRIPTION
## Summary
- add dark mode state and toggle in navbar
- theme variables and small body styling
- keep navbar inverse colour from body

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684096fc305c83248bc2a8044296e67d