### PR TITLE
Add sortable pass list with preview

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ function App() {
                 <Route path="/customers" element={<Customers />} />
                 <Route path="/create-pass" element={<CreatePass />} />
                 <Route path="/update-pass" element={<UpdatePass />} />
+                <Route path="/update-pass/:serial" element={<UpdatePass />} />
             </Routes>
         </div>
     );


### PR DESCRIPTION
## Summary
- allow navigation to `/update-pass/:serial`
- revamp update pass page with a searchable, sortable table of passes
- preview a pass when hovering over a row

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852fe5bd6388324ba5e01c3da7c7847